### PR TITLE
Verify range data in jp2_pclr_getdata

### DIFF
--- a/src/libjasper/jp2/jp2_cod.c
+++ b/src/libjasper/jp2/jp2_cod.c
@@ -855,6 +855,12 @@ static int jp2_pclr_getdata(jp2_box_t *box, jas_stream_t *in)
 	  jp2_getuint8(in, &pclr->numchans)) {
 		return -1;
 	}
+
+	// verify in range data as per I.5.3.4 - Palette box
+	if (pclr->numchans < 1 || pclr->numlutents < 1 || pclr->numlutents > 1024) {
+		return -1;
+	}
+
 	lutsize = pclr->numlutents * pclr->numchans;
 	if (!(pclr->lutdata = jas_alloc2(lutsize, sizeof(int_fast32_t)))) {
 		return -1;


### PR DESCRIPTION
This fixes CVE-2018-19541.
We need to verify the data is in the expected range. Otherwise we get
problems later.

This is a better fix for https://github.com/mdadams/jasper/pull/199
which caused segfaults under certain circumstances.

Patch by Adam Majer <adam.majer@suse.de>

See: https://github.com/mdadams/jasper/pull/211
Fix https://github.com/jasper-maint/jasper/issues/6