### PR TITLE
Use return in jpc_dec_process_sot() instead of abort

### DIFF
--- a/src/libjasper/jpc/jpc_dec.c
+++ b/src/libjasper/jpc/jpc_dec.c
@@ -485,7 +485,7 @@ static int jpc_dec_process_sot(jpc_dec_t *dec, jpc_ms_t *ms)
 
 		if (!(compinfos = jas_alloc2(dec->numcomps,
 		  sizeof(jas_image_cmptparm_t)))) {
-			abort();
+			return -1;
 		}
 		for (cmptno = 0, cmpt = dec->cmpts, compinfo = compinfos;
 		  cmptno < dec->numcomps; ++cmptno, ++cmpt, ++compinfo) {
@@ -512,7 +512,7 @@ static int jpc_dec_process_sot(jpc_dec_t *dec, jpc_ms_t *ms)
 			/* Convert the PPM marker segment data into a collection of streams
 			  (one stream per tile-part). */
 			if (!(dec->pkthdrstreams = jpc_ppmstabtostreams(dec->ppmstab))) {
-				abort();
+				return -1;
 			}
 			jpc_ppxstab_destroy(dec->ppmstab);
 			dec->ppmstab = 0;


### PR DESCRIPTION
We don't need to and should not abort here.

Fix CVE-2018-9154.
Fix https://github.com/mdadams/jasper/issues/215
Fix https://github.com/mdadams/jasper/issues/166
Fix https://github.com/mdadams/jasper/issues/175

See: https://github.com/mdadams/jasper/pull/216
Fix https://github.com/jasper-maint/jasper/issues/8