### PR TITLE
jpc_dec: fix tile memory leak after decoder failure

### DIFF
--- a/src/libjasper/jpc/jpc_dec.c
+++ b/src/libjasper/jpc/jpc_dec.c
@@ -1310,6 +1310,15 @@ static int jpc_dec_process_siz(jpc_dec_t *dec, jpc_ms_t *ms)
 
 	for (tileno = 0, tile = dec->tiles; tileno < dec->numtiles; ++tileno,
 	  ++tile) {
+		/* initialize all tiles with JPC_TILE_DONE so
+		   jpc_dec_destroy() knows which ones need a
+		   jpc_dec_tilefini() call; they are not actually
+		   "done", of course */
+		tile->state = JPC_TILE_DONE;
+	}
+
+	for (tileno = 0, tile = dec->tiles; tileno < dec->numtiles; ++tileno,
+	  ++tile) {
 		htileno = tileno % dec->numhtiles;
 		vtileno = tileno / dec->numhtiles;
 		tile->realmode = 0;
@@ -2020,6 +2029,16 @@ static void jpc_dec_destroy(jpc_dec_t *dec)
 	}
 
 	if (dec->tiles) {
+		int tileno;
+		jpc_dec_tile_t *tile;
+
+		for (tileno = 0, tile = dec->tiles; tileno < dec->numtiles; ++tileno,
+		  ++tile) {
+			if (tile->state != JPC_TILE_DONE) {
+				jpc_dec_tilefini(dec, tile);
+			}
+		}
+
 		jas_free(dec->tiles);
 	}
 


### PR DESCRIPTION
(Re-posting https://github.com/mdadams/jasper/pull/159)

The function jpc_dec_tilefini() is only called for tiles which have
completed successfully.  If there is one decoder error, all unfinished
tiles leak lots of memory.

This change adds jpc_dec_tilefini() calls to jpc_dec_destroy() for
each tile which is not marked "done" (state!=JPC_TILE_DONE).  This
however crashes when the tile initialization loop in
jpc_dec_process_siz() fails, because the rest of the array has not yet
been initialized; to work around this, I added a loop which
initializes all states with JPC_TILE_DONE before doing the real
initialization.