### PR TITLE
Exit upon invalid MTYP in CMAP box

### DIFF
--- a/src/libjasper/jp2/jp2_dec.c
+++ b/src/libjasper/jp2/jp2_dec.c
@@ -396,6 +396,9 @@ jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr)
 				jas_image_setcmpttype(dec->image, newcmptno, jp2_getct(jas_image_clrspc(dec->image), 0, channo + 1));
 				}
 #endif
+			} else {
+				jas_eprintf("error: invalid MTYP in CMAP box\n");
+				goto error;
 			}
 		}
 	}


### PR DESCRIPTION
Patch by Timothy Lyanguzov <timothy.lyanguzov@sap.com>
originally proposed at https://github.com/mdadams/jasper/pull/200.

To fix https://github.com/mdadams/jasper/issues/182.
Instead of https://github.com/mdadams/jasper/pull/197 /
https://gist.github.com/apoleon/701d7db34d63faa16463935b1465c74e.

Fix https://github.com/jasper-maint/jasper/issues/7