### PR TITLE
CMakeLists.txt: enable -fvisibility=hidden for internal symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,17 @@ if (JAS_ENABLE_HIDDEN AND NOT WIN32)
 	if (JAS_HAVE_VISIBILITY)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -DJAS_HAVE_VISIBILITY")
 	endif()
+
+	if (NOT (CMAKE_BUILD_TYPE MATCHES "Debug"))
+		# remove unused internal symbols
+		check_c_compiler_flag("-ffunction-sections" HAVE_FUNCTION_SECTIONS)
+		check_c_compiler_flag("-fdata-sections" HAVE_DATA_SECTIONS)
+		check_c_compiler_flag("-Wl,--gc-sections" HAVE_GC_SECTIONS)
+
+		if (HAVE_FUNCTION_SECTIONS AND HAVE_DATA_SECTIONS AND HAVE_GC_SECTIONS)
+			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -Wl,--gc-sections")
+		endif()
+	endif()
 endif()
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,8 +249,12 @@ check_function_exists(getrusage JAS_HAVE_GETRUSAGE)
 # Check for the JPEG library.
 ################################################################################
 
-find_package(JPEG ${JAS_LIBJPEG_REQUIRED})
-message("JPEG library found: ${JPEG_FOUND}")
+if (JAS_ENABLE_LIBJPEG)
+	find_package(JPEG ${JAS_LIBJPEG_REQUIRED})
+	message("JPEG library found: ${JPEG_FOUND}")
+else()
+	set(JPEG_FOUND false)
+endif()
 if (JAS_ENABLE_LIBJPEG AND JPEG_FOUND)
 	set(JAS_HAVE_LIBJPEG 0)
 	message("JPEG include directory: ${JPEG_INCLUDE_DIR}")
@@ -289,9 +293,13 @@ message("JAS_HAVE_LIBJPEG: ${JAS_HAVE_LIBJPEG}")
 # Check for the OpenGL and GLUT libraries.
 ################################################################################
 
-find_package(OpenGL ${JAS_REQUIRED})
 message("JAS_ENABLE_OPENGL: ${JAS_ENABLE_OPENGL}")
-message("OpenGL library found: ${OPENGL_FOUND}")
+if (JAS_ENABLE_OPENGL)
+	find_package(OpenGL ${JAS_REQUIRED})
+	message("OpenGL library found: ${OPENGL_FOUND}")
+else()
+	set(OPENGL_FOUND false)
+endif()
 if (JAS_ENABLE_OPENGL AND OPENGL_FOUND)
 	set(JAS_HAVE_OPENGL 0)
 	message("OpenGL include directory: ${OPENGL_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_MODULE_PATH
 # This include should be placed as early as possible.
 include(InSourceBuild)
 
+include(CheckCCompilerFlag)
+
 ################################################################################
 # Version information.
 ################################################################################
@@ -85,6 +87,7 @@ cmake_policy(SET CMP0012 NEW)
 ################################################################################
 
 option(JAS_ENABLE_SHARED "Enable building of shared library" true)
+option(JAS_ENABLE_HIDDEN "Hide internal symbols" false)
 option(JAS_ENABLE_LIBJPEG "Enable the use of the JPEG Library" true)
 option(JAS_ENABLE_OPENGL "Enable the use of the OpenGL/GLUT Library" true)
 option(JAS_ENABLE_STRICT "Enable pedantic error checking" false)
@@ -193,6 +196,14 @@ if (JAS_STRICT)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wformat -Wmissing-prototypes -Wstrict-prototypes")
+endif()
+
+if (JAS_ENABLE_HIDDEN AND NOT WIN32)
+	# don't export internal symbols
+	check_c_compiler_flag("-fvisibility=hidden" JAS_HAVE_VISIBILITY)
+	if (JAS_HAVE_VISIBILITY)
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -DJAS_HAVE_VISIBILITY")
+	endif()
 endif()
 
 ################################################################################

--- a/INSTALL
+++ b/INSTALL
@@ -117,6 +117,10 @@ JAS_ENABLE_SHARED
     Enable the building of shared libraries.
     Valid values: true or false
 
+JAS_ENABLE_HIDDEN
+    Hide internal symbols?  Enabling this results in a smaller binary.
+    Valid values: true or false
+
 JAS_ENABLE_ASAN
     Enable the Address Sanitizer.
     Valid values: true or false


### PR DESCRIPTION
Don't export internal symbols in the public symbol table.  This
reduces the number of exported symbols from 348 to 121.

The same is already being done on Windows by using
`__declspec(dllexport)`, and all functions not annotated with it will
be inaccessible by programs using JasPer.

Strangely, this refuses access to lots of functions in the public
headers.  I wonder why these were declared in the public headers.