### PR TITLE
jas_seq, jpc_fix: add option to use 32-bit integers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ cmake_policy(SET CMP0012 NEW)
 
 option(JAS_ENABLE_SHARED "Enable building of shared library" true)
 option(JAS_ENABLE_HIDDEN "Hide internal symbols" false)
+option(JAS_ENABLE_32BIT "Use 32 bit integers on 64 bit CPUs" false)
 option(JAS_ENABLE_LIBJPEG "Enable the use of the JPEG Library" true)
 option(JAS_ENABLE_OPENGL "Enable the use of the OpenGL/GLUT Library" true)
 option(JAS_ENABLE_STRICT "Enable pedantic error checking" false)

--- a/INSTALL
+++ b/INSTALL
@@ -121,6 +121,13 @@ JAS_ENABLE_HIDDEN
     Hide internal symbols?  Enabling this results in a smaller binary.
     Valid values: true or false
 
+JAS_ENABLE_32BIT
+    Force the use of 32 bit integers?  On 64 bit CPUs, JasPer
+    historically used 64 bit integers which consumes more memory, is
+    slower and has no advantages.  This produces a different ABI, so
+    the resulting library is not compatible with other builds.
+    Valid values: true or false
+
 JAS_ENABLE_ASAN
     Enable the Address Sanitizer.
     Valid values: true or false

--- a/src/libjasper/include/jasper/jas_config.h.in
+++ b/src/libjasper/include/jasper/jas_config.h.in
@@ -16,6 +16,8 @@
 /* This preprocessor symbol identifies the version of JasPer. */
 #define	JAS_VERSION "@JAS_VERSION@"
 
+#cmakedefine JAS_ENABLE_32BIT 1
+
 #cmakedefine JAS_HAVE_FCNTL_H 1
 #cmakedefine JAS_HAVE_IO_H 1
 #cmakedefine JAS_HAVE_UNISTD_H 1

--- a/src/libjasper/include/jasper/jas_seq.h
+++ b/src/libjasper/include/jasper/jas_seq.h
@@ -98,12 +98,24 @@ extern "C" {
 \******************************************************************************/
 
 /* An element in a sequence. */
+#ifdef JAS_ENABLE_32BIT
+typedef int_least32_t jas_seqent_t;
+#else
 typedef int_fast32_t jas_seqent_t;
+#endif
 
 /* An element in a matrix. */
+#ifdef JAS_ENABLE_32BIT
+typedef int_least32_t jas_matent_t;
+#else
 typedef int_fast32_t jas_matent_t;
+#endif
 
+#ifdef JAS_ENABLE_32BIT
+typedef int_least32_t jas_matind_t;
+#else
 typedef int_fast32_t jas_matind_t;
+#endif
 
 /* Matrix. */
 

--- a/src/libjasper/jpc/jpc_fix.h
+++ b/src/libjasper/jpc/jpc_fix.h
@@ -74,6 +74,7 @@
 * Includes.
 \******************************************************************************/
 
+#include "jasper/jas_config.h"
 #include "jasper/jas_types.h"
 #include "jasper/jas_fix.h"
 #include "jasper/jas_math.h"
@@ -85,7 +86,11 @@
 /* The integral type used to represent a fixed-point number.  This
   type must be capable of representing values from -(2^31) to 2^31-1
   (inclusive). */
+#ifdef JAS_ENABLE_32BIT
+typedef int_least32_t jpc_fix_t;
+#else
 typedef int_fast32_t jpc_fix_t;
+#endif
 
 /* The integral type used to respresent higher-precision intermediate results.
   This type should be capable of representing values from -(2^63) to 2^63-1


### PR DESCRIPTION
Those libraries use the C99 type `int_fast32_t`, which translates to
`int64_t` on AMD64.  This type obviously consumes twice as much memory
as `int32_t`, and these two libraries are mostly about allocating bulk
buffers containing these values.

More memory use for large buffers means a larger working set, which
results in reduced CPU cache efficiency.  So in these cases,
`int_fast32_t` is not actually the "fastest" integer, but the slowest.

This is a "perf stat imginfo -f balloon.jp2" with the 64 bit ABI (on
an Intel Xeon E5-2630):

       1010.691814      task-clock:u (msec)       #    0.999 CPUs utilized
     6,129,118,094      instructions:u
         7,518,301      cache-misses:u            #    7.132 % of all cache refs
       105,422,064      cache-references:u        #  104.307 M/sec

And this is with the 32 bit ABI:

        934.800857      task-clock:u (msec)       #    0.999 CPUs utilized
     6,234,900,095      instructions:u
           789,609      cache-misses:u            #    1.130 % of all cache refs
        69,876,685      cache-references:u        #   74.750 M/sec

       0.935685960 seconds time elapsed

The 32 bit ABI is about 8% faster, even though it executes more CPU
instructions.  That is because it wastes less time waiting for the CPU
cache: only 1.1% cache misses instead of 7.1%.

The problem is that the choice of using `int_fast32_t` everywhere has
leaked into the JasPer ABI, and changing it now will break ABI
compatibility.

So for people who can afford an ABI breakage, this patch adds a new
compile-time option `JAS_ENABLE_32BIT` which builds a more efficient
32 bit ABI.